### PR TITLE
Payment channel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 .next
 smart-contract/build
+smart-contract/contract-address.txt

--- a/smart-contract/contracts/PlanetFlareCoin.sol
+++ b/smart-contract/contracts/PlanetFlareCoin.sol
@@ -169,4 +169,6 @@ contract PlanetFlareCoin {
 
         return true;
     }
+
+    /* Payment Channel */
 }

--- a/smart-contract/deploy-contract.sh
+++ b/smart-contract/deploy-contract.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+echo $(truffle migrate | grep 'contract address' | tail -1 | sed 's/^.*: //') > contract-address.txt

--- a/smart-contract/package-lock.json
+++ b/smart-contract/package-lock.json
@@ -1,6 +1,8 @@
 {
-  "requires": true,
+  "name": "planetflare-contract",
+  "version": "0.1.0",
   "lockfileVersion": 1,
+  "requires": true,
   "dependencies": {
     "@ethersproject/abi": {
       "version": "5.0.0-beta.153",
@@ -849,6 +851,15 @@
         "scrypt-js": "^3.0.0",
         "secp256k1": "^4.0.1",
         "setimmediate": "^1.0.5"
+      }
+    },
+    "ethereumjs-abi": {
+      "version": "0.6.8",
+      "resolved": "https://registry.npmjs.org/ethereumjs-abi/-/ethereumjs-abi-0.6.8.tgz",
+      "integrity": "sha512-Tx0r/iXI6r+lRsdvkFDlut0N08jWMnKRZ6Gkq+Nmw75lZe4e6o3EkSnkaBP5NF6+m5PTGAr9JP43N3LyeoglsA==",
+      "requires": {
+        "bn.js": "^4.11.8",
+        "ethereumjs-util": "^6.0.0"
       }
     },
     "ethereumjs-common": {

--- a/smart-contract/package.json
+++ b/smart-contract/package.json
@@ -7,6 +7,7 @@
     "test": "test"
   },
   "dependencies": {
+    "ethereumjs-abi": "^0.6.8",
     "web3": "^1.2.11"
   },
   "devDependencies": {},

--- a/smart-contract/payment-channel.js
+++ b/smart-contract/payment-channel.js
@@ -1,0 +1,14 @@
+var abi = require('ethereumjs-abi');
+
+function generateSignatureHash(recipient, bountyID, amount, nonce) {
+    var hash = "0x" + abi.soliditySHA3(
+        ["address", "uint256", "uint256", "uint256"],
+        [recipient, bountyID, amount, nonce]
+    ).toString("hex");
+
+    return hash;
+}
+
+module.exports = {
+    generateSignatureHash: generateSignatureHash
+};

--- a/smart-contract/run-local-node.sh
+++ b/smart-contract/run-local-node.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-ganache-cli -d
+ganache-cli -d --allowUnlimitedContractSize -l 10000000000000

--- a/smart-contract/testBounty.js
+++ b/smart-contract/testBounty.js
@@ -11,10 +11,11 @@ let rl = readline.createInterface({
 let web3 = new Web3('ws://localhost:8545')
 
 const PFCContractBuild = JSON.parse(fs.readFileSync('./build/contracts/PlanetFlareCoin.json'));
-console.log(PFCContractBuild.abi);
 
-rl.question('Enter deployed contract address: ', function (contractAddress) {
-    let PlanetFlareContract = new web3.eth.Contract(PFCContractBuild.abi, contractAddress);
-    console.log(PlanetFlareContract);
-    rl.close();
-});
+const contractAddress = fs.readFileSync('./contract-address.txt', 'ascii').trim();
+console.log(contractAddress);
+
+let PlanetFlareContract = new web3.eth.Contract(PFCContractBuild.abi, contractAddress);
+console.log(PlanetFlareContract);
+
+process.exit();

--- a/smart-contract/testBounty.js
+++ b/smart-contract/testBounty.js
@@ -1,6 +1,9 @@
 const Web3 = require('web3');
 const readline = require('readline');
 const fs = require('fs');
+const PaymentChannel = require('./payment-channel');
+const { create } = require('domain');
+const { randomBytes } = require('crypto');
 
 let rl = readline.createInterface({
     input: process.stdin,
@@ -13,9 +16,76 @@ let web3 = new Web3('ws://localhost:8545')
 const PFCContractBuild = JSON.parse(fs.readFileSync('./build/contracts/PlanetFlareCoin.json'));
 
 const contractAddress = fs.readFileSync('./contract-address.txt', 'ascii').trim();
-console.log(contractAddress);
 
 let PlanetFlareContract = new web3.eth.Contract(PFCContractBuild.abi, contractAddress);
-console.log(PlanetFlareContract);
 
-process.exit();
+var primaryAccount = web3.eth.accounts.privateKeyToAccount('0x4f3edf983ac636a65a842ce7c78d9aa706d3b113bce9c46f30d7d21715b23b1d');
+var secondaryAccount = web3.eth.accounts.privateKeyToAccount('0x6cbed15c793ce57650b9877cf6fa156fbef513c4e6134f022a85b1ffdd59b2a1')
+
+function getPrimaryBalance(callback) {
+    PlanetFlareContract.methods.balanceOf(secondaryAccount.address).call(callback);
+}
+
+function transferPFC(amount, callback) {
+    PlanetFlareContract.methods.transfer(secondaryAccount.address, amount).send(
+        {from: primaryAccount.address},
+        callback
+    );
+}
+
+function createBounty(cid, costPerToken, deposit, callback) {
+    PlanetFlareContract.methods.createBounty(cid, costPerToken, deposit).send(
+        { from: primaryAccount.address, gas: 100000000 },
+    ).then(callback)
+    .catch(console.log);
+}
+
+function getBountyIDs(publisher, callback) {
+    PlanetFlareContract.methods.getBountiesForPublisher(publisher).call(callback);
+}
+
+function getBounty(id, callback) {
+    PlanetFlareContract.methods.getBounty(id).call(callback)
+}
+
+function paymentChannelTest() {
+    var bountyID = '88735044318772147556240327665446902972523722668274298936251860056363735820129';
+    var amount = 100;
+    var nonce = Math.floor(Math.random() * 10000000);
+
+    let signatureHash = PaymentChannel.generateSignatureHash(
+        secondaryAccount.address,
+        bountyID,
+        amount,
+        nonce
+    );
+    console.log(primaryAccount);
+
+    let signature = web3.eth.accounts.sign(signatureHash, primaryAccount.privateKey).signature;
+
+    PlanetFlareContract.methods.claimPayment(
+        bountyID,
+        amount,
+        nonce,
+        signature
+    ).send({from: secondaryAccount.address}).then(console.log).catch(console.log)
+}
+
+function deleteBounty() {
+    PlanetFlareContract.methods.deleteBounty(
+        '88735044318772147556240327665446902972523722668274298936251860056363735820129'
+    ).send({ from: primaryAccount.address }).then(console.log);
+}
+
+// transferPFC(100, console.log);
+// createBounty('example-cid', 5, 200, function (receipt) {
+//     console.log(receipt.events['BountyUpdate'].returnValues);
+// });
+
+// getBountyIDs(primaryAccount.address, function(error, bountyIDs) {
+//     bountyIDs.forEach(id => getBounty(id, (_, r) => console.log(r)));
+// });
+
+// paymentChannelTest();
+
+deleteBounty();


### PR DESCRIPTION
Code is messy and sitting in a bunch of test files with hardcoded values -- but the stuff I wrote over there shows exactly how signatures/proofs are going to work on the publisher side.

Providers will submit their tokens to the publisher, along with a proof of the current state of microtransactions. Publishers will take this and return a new signed proof of microtransaction state. At any point, providers can submit these proofs to the chain for their payout in PFC.

This has also been protected against double-attacks (where you try to use the same proof more than once) because of the nonce field. 